### PR TITLE
Replace "com" with "net" in the mixin config file

### DIFF
--- a/src/main/resources/elixiradventures.mixins.json
+++ b/src/main/resources/elixiradventures.mixins.json
@@ -1,6 +1,6 @@
 {
 	"required": true,
-	"package": "com.hsneptune.elixiradventures.mixin",
+	"package": "net.hsneptune.elixiradventures.mixin",
 	"compatibilityLevel": "JAVA_17",
 	"mixins": [
 		"ElixirAdventuresMixin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
 		],
 		"client": ["net.hsneptune.elixiradventures.ElixirAdventuresClient"],
 		"fabric-datagen": [
-			"net.hsneptune.elixiradventures.ElixirAdventuresDataGenerator"
+			"net.hsneptune.elixiradventures.ElixirAdventuresGenerator"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
The mixin file had com instead of net for the mixin package path. It caused the client to not start up.